### PR TITLE
Change to Django 2.0.8 due to security vuln

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django==2
+Django==2.0.8


### PR DESCRIPTION
Django 2.0 has security vulnerabilities as per:
https://nvd.nist.gov/vuln/detail/CVE-2018-6188
https://nvd.nist.gov/vuln/detail/CVE-2018-14574